### PR TITLE
New migration and imap_api correction

### DIFF
--- a/.db/migrations/2020-03-20-1_mail_server_settings_correction.py
+++ b/.db/migrations/2020-03-20-1_mail_server_settings_correction.py
@@ -1,0 +1,17 @@
+def update():
+    return """
+    
+    ALTER TABLE mail_server_settings RENAME TO tmp_mail_server_settings;
+
+    CREATE TABLE IF NOT EXISTS mail_server_settings (
+            id integer PRIMARY KEY,
+            service_name text NOT NULL,
+            server_smtp text,
+            server_imap text,
+            ssl integer,
+            ssl_context integer,
+            starttls integer
+        );
+
+    DROP TABLE tmp_mail_server_settings;
+    """

--- a/py_modules/imap_api.py
+++ b/py_modules/imap_api.py
@@ -27,17 +27,17 @@ class ImapApi:
         # Getting the imap configuration
 
         ## Converting
-        if backend_api.get_user_server_config("ssl") == "True":
+        if backend_api.get_user_server_config("ssl") == 1:
             self.ssl = True
         else:
             self.ssl = False
 
-        if backend_api.get_user_server_config("ssl_context") == "True":
+        if backend_api.get_user_server_config("ssl_context") == 1:
             self.ssl_context = True
         else:
             self.ssl_context = None
 
-        if backend_api.get_user_server_config("starttls") == "True":
+        if backend_api.get_user_server_config("starttls") == 1:
             self.starttls = True
         else:
             self.starttls = False


### PR DESCRIPTION
Created a new migration that drops the table mail_server_settings 

and re-create it in order to alter the last three columns to be integer.
in imap_api changed the converting part so it matches integer 1 instead of "True"